### PR TITLE
Use the reader monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ should see an alert popup on screen.
 > let channel = "test_channel"
 > let event = Event "my_event" "{\"message\":\"hello world\"}"
 
-> triggerEvent pusher channel event
+> triggerEvent (pusher, channel, event)
 "{}"
 
-> getChannelInfo pusher channel []
+> getChannelInfo (pusher, channel, [])
 Right (ChannelInfo {occupied = True, userCount = Nothing, subscriptionCount = Nothing})
 ```
 
@@ -36,7 +36,7 @@ You can also trigger events across multiple channels:
 > let channels = ["first_channel", "second_channel"]
 > ...
 
-> triggerEvent pusher channels event
+> triggerMultiChannelEvent (pusher, channels, event)
 "{}"
 ```
 

--- a/pusher-haskell.cabal
+++ b/pusher-haskell.cabal
@@ -26,6 +26,7 @@ library
     HTTP >= 4000.2.19,
     SHA  >= 1.6.4.1,
     MissingH >= 1.3.0.1,
+    mtl >= 2.2.1,
     bytestring >= 0.10.4.0,
     time >= 1.4.2
   hs-source-dirs:      src

--- a/src/Network/Pusher/Channel.hs
+++ b/src/Network/Pusher/Channel.hs
@@ -31,7 +31,7 @@ import Network.Pusher.Base
 
 type Environment = (Pusher, Channel, [Info])
 
--- | @getChannelInfo pusher channel info@ requests information about a
+-- | @getChannelInfo (pusher, channel, info)@ requests information about a
 -- particular channel for the given 'Pusher' instance. The result is either an
 -- error message returned by the Pusher server, or a 'ChannelInfo' data
 -- structure.

--- a/src/Network/Pusher/Event.hs
+++ b/src/Network/Pusher/Event.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-module Network.Pusher.Event (triggerEvent, triggerMultiChannelEvent) where
+module Network.Pusher.Event (triggerEvent, triggerMultiChannelEvent, Environment) where
 
 import Network.HTTP
 import Control.Applicative
@@ -29,9 +29,15 @@ import Network.Pusher.Base
 
 type Environment = (Pusher, String, Event)
 
+-- | @triggerEvent (pusher, channel, event)@ sends an event to one
+-- channel for the given 'Pusher' instance. The result is the response body
+-- from the Pusher server.
 triggerEvent :: Environment -> IO String
 triggerEvent (p, c, e) = runReaderT event (p, requestBody c e, e)
 
+-- | @triggerMultiChannelEvent (pusher, channels, event)@ sends an event to multiple
+-- channels for the given 'Pusher' instance. The result is the response body
+-- from the Pusher server.
 triggerMultiChannelEvent :: Environment -> IO String
 triggerMultiChannelEvent (p, cs, e) = runReaderT event (p, requestMultiChannelBody cs e, e)
 
@@ -73,14 +79,6 @@ unsignedAuthString t b = do
   liftIO $ idKeyAndTimestamp appId appKey
     <$> t
     >>= (\u -> return $ u ++ "&auth_version=1.0&body_md5=" ++ b)
-
--- | @triggerEvent pusher channel event@ sends an event to one
--- channel for the given 'Pusher' instance. The result is the response body
--- from the Pusher server.
-
--- | @triggerMultiChannelEvent pusher channels event@ sends an event to multiple
--- channels for the given 'Pusher' instance. The result is the response body
--- from the Pusher server.
 
 requestBody c e = "{\"name\": \""
                 ++ (eventName e)


### PR DESCRIPTION
This way, we're not passing around the same arguments over and over.

Before this gets merged, we should also use `ReaderT`-ify `Network.Pusher.Event` too
