### PR TITLE
Multi-channel API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Pusher](http://www.pusher.com) server client written in Haskell.
 Currently, the package allows:
 
 * Triggering events on single or multiple channels
-* Fetching basic information about a given channel
+* Fetching basic information about single or multiple channels
 
 Up next:
 
@@ -38,6 +38,14 @@ You can also trigger events across multiple channels:
 
 > triggerMultiChannelEvent (pusher, channels, event)
 "{}"
+```
+
+And fetch information about all channels:
+```haskell
+> ...
+
+> getMultiChannelInfo (pusher, [], Nothing)
+Right (ChannelList [Channel {name = "test_channel", cUserCount = Nothing}])
 ```
 
 ## Documentation

--- a/pusher-haskell.cabal
+++ b/pusher-haskell.cabal
@@ -28,7 +28,8 @@ library
     MissingH >= 1.3.0.1,
     mtl >= 2.2.1,
     bytestring >= 0.10.4.0,
-    time >= 1.4.2
+    time >= 1.4.2,
+    containers >= 0.5.6.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/src/Network/Pusher/Event.hs
+++ b/src/Network/Pusher/Event.hs
@@ -29,16 +29,16 @@ import Network.Pusher.Base
 
 type Environment = (Pusher, String, Event)
 
--- | @triggerEvent (pusher, channel, event)@ sends an event to one
+-- | @triggerEvent (pusher, channelName, event)@ sends an event to one
 -- channel for the given 'Pusher' instance. The result is the response body
 -- from the Pusher server.
-triggerEvent :: (Pusher, Channel, Event) -> IO String
+triggerEvent :: (Pusher, ChannelName, Event) -> IO String
 triggerEvent (p, c, e) = runReaderT event (p, requestBody c e, e)
 
--- | @triggerMultiChannelEvent (pusher, channels, event)@ sends an event to multiple
+-- | @triggerMultiChannelEvent (pusher, channelNames, event)@ sends an event to multiple
 -- channels for the given 'Pusher' instance. The result is the response body
 -- from the Pusher server.
-triggerMultiChannelEvent :: (Pusher, [Channel], Event) -> IO String
+triggerMultiChannelEvent :: (Pusher, ChannelNames, Event) -> IO String
 triggerMultiChannelEvent (p, cs, e) = runReaderT event (p, requestMultiChannelBody cs e, e)
 
 event :: ReaderT Environment IO String


### PR DESCRIPTION
Allows requesting information about all channels for a given `Pusher`
instance.

Basically solves https://github.com/sidraval/pusher-haskell/issues/1 though there are some options that are unaccounted for here.
